### PR TITLE
replace pin-project with pin-project-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "nix 0.30.1",
- "pin-project",
+ "pin-project-lite",
  "rustc_version",
  "serialport",
 ]
@@ -407,26 +407,6 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ nightly = []
 futures-io = "0.3"
 futures-util = { version = "0.3", default-features = false }
 nix = { version = "0.30", features = ["event", "fs", "signal", "time"] }
-pin-project = "1"
+pin-project-lite = "0.2"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,6 @@
 use crate::Timer;
 use futures_util::FutureExt;
+use pin_project_lite::pin_project;
 use std::{task::Poll, time::Duration};
 
 /// Run the inner [`Future`] until it completes, or `duration` elapses -
@@ -10,11 +11,12 @@ pub fn timeout<F: Future>(duration: Duration, future: F) -> std::io::Result<Time
     Ok(Timeout { future, timer })
 }
 
-#[pin_project::pin_project]
-pub struct Timeout<F: Future> {
-    #[pin]
-    future: F,
-    timer: Timer,
+pin_project! {
+    pub struct Timeout<F: Future> {
+        #[pin]
+        future: F,
+        timer: Timer,
+    }
 }
 
 impl<F: Future> Future for Timeout<F> {


### PR DESCRIPTION
before
```
> cargo tree -e normal
epox v0.1.0 (/home/alex/code/epox)
├── futures-io v0.3.31
├── futures-util v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-task v0.3.31
│   ├── pin-project-lite v0.2.16
│   └── pin-utils v0.1.0
├── nix v0.30.1
│   ├── bitflags v2.9.4
│   ├── cfg-if v1.0.3
│   └── libc v0.2.175
└── pin-project v1.1.10
    └── pin-project-internal v1.1.10 (proc-macro)
        ├── proc-macro2 v1.0.101
        │   └── unicode-ident v1.0.18
        ├── quote v1.0.40
        │   └── proc-macro2 v1.0.101 (*)
        └── syn v2.0.106
            ├── proc-macro2 v1.0.101 (*)
            ├── quote v1.0.40 (*)
            └── unicode-ident v1.0.18
```

after
```
> cargo tree -e normal
epox v0.1.0 (/home/alex/code/epox)
├── futures-io v0.3.31
├── futures-util v0.3.31
│   ├── futures-core v0.3.31
│   ├── futures-task v0.3.31
│   ├── pin-project-lite v0.2.16
│   └── pin-utils v0.1.0
├── nix v0.30.1
│   ├── bitflags v2.9.4
│   ├── cfg-if v1.0.3
│   └── libc v0.2.175
└── pin-project-lite v0.2.16
```