### PR TITLE
executor: return errors on shutdown

### DIFF
--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -7,7 +7,7 @@ fn main() {
         let received = rx.recv().await?;
         let took = std::time::Instant::now().duration_since(begin);
         println!("received '{received}' in async task; took {took:?}");
-        Ok::<_, Box<dyn std::error::Error>>(())
+        Ok(())
     });
 
     std::thread::spawn(move || {
@@ -19,8 +19,5 @@ fn main() {
 
     epox::run().unwrap();
 
-    handle
-        .result()
-        .expect("async task didn't complete")
-        .unwrap();
+    handle.result().expect("async task didn't complete");
 }

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -9,7 +9,7 @@ fn main() {
             stdin_reader.read_line(&mut line).await?;
             let line = line.trim();
             println!("read line: {line}");
-            Ok::<_, Box<dyn std::error::Error>>(())
+            Ok::<(), std::io::Error>(())
         })?
         .await
         {
@@ -18,9 +18,9 @@ fn main() {
             }
             Err(()) => println!("timed out waiting for line"),
         }
-        Ok::<_, Box<dyn std::error::Error>>(())
+        Ok(())
     });
 
     epox::run().unwrap();
-    handle.result().unwrap().unwrap();
+    handle.result().unwrap();
 }

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -6,7 +6,7 @@ const TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_secs(1);
 fn timeout() {
     let handle = epox::spawn_checked(async {
         match epox::time::timeout(TIMEOUT_DURATION, takes_one_minute())?.await {
-            Ok(_) => Ok::<_, Box<dyn std::error::Error>>(false),
+            Ok(_) => Ok(false),
             Err(()) => Ok(true),
         }
     });
@@ -14,7 +14,7 @@ fn timeout() {
     let begin = std::time::Instant::now();
     epox::run().unwrap();
     let took = std::time::Instant::now().duration_since(begin);
-    let handle_timed_out = handle.result().expect("task should have finished").unwrap();
+    let handle_timed_out = handle.result().expect("task should have finished");
     assert!(handle_timed_out);
     // should be within 5% of TIMEOUT_DURATION
     assert!(took.abs_diff(TIMEOUT_DURATION) < (TIMEOUT_DURATION / 20));


### PR DESCRIPTION
Previously handling errors from a task which was spawned with
spawn_checked required some hoop jumping with handles. Instead, return
the error from the failed task from epox::run().
