### PR TITLE
Cargo.toml: update `[package]` section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 rust-version = "1.87.0"
 license = "MIT"
 description = "An epoll driven async executor."
+repository = "https://github.com/relectrify/epox"
+categories = ["asynchronous"]
+keywords = ["async", "epoll", "linux"]
 
 [features]
 default = []


### PR DESCRIPTION
adds repository, categories and keywords as suggested by the Rust API Guidelines

https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata

the authors field has not been included as it is now deprecated

https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field